### PR TITLE
adding 16.04 to list of good linux distros

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,7 @@ default['apt-docker']['supported-codenames'] = {
   utopic: true,  # Ubuntu 14.10
   vivid: true,   # Ubuntu 15.04
   wily: true,    # Ubuntu 15.10
+  xenial: true,  # Ubuntu 16.04
 }
 
 uri = 'https://apt.dockerproject.org/repo'


### PR DESCRIPTION
I tested this with an override on the jenkins box I'm building and it works file. Ubuntu 16 also was not out at the time we forked this so there's no way it would've been in this list then.